### PR TITLE
Improvement: Better time "resolution" in statistics

### DIFF
--- a/FIBPlatforms.pas
+++ b/FIBPlatforms.pas
@@ -70,6 +70,10 @@ type
 {$ENDIF}
 
  function FIBGetTickCount: Cardinal;
+ {$IFDEF WINDOWS}
+ function FIBGetTickCountHR: Int64;
+ function FIBGetTickCountFQ: Int64;
+ {$ENDIF}
  procedure TerminateApplication;
  function ApplicationPath:string;
  function CurrentThreadID:DWORD;
@@ -116,6 +120,16 @@ end;
    function FIBGetTickCount: Cardinal;
    begin
       Result := Windows.GetTickCount;
+   end;
+
+   function FIBGetTickCountHR: Int64;
+   begin
+      QueryPerformanceCounter(Result);
+   end;
+
+   function FIBGetTickCountFQ: Int64;
+   begin
+      QueryPerformanceFrequency(Result);
    end;
 
    procedure TerminateApplication;

--- a/FIBQuery.pas
+++ b/FIBQuery.pas
@@ -3784,6 +3784,7 @@ begin
  if Assigned(Database.SQLStatisticsMaker) and  Database.SQLStatisticsMaker.ActiveStatistics then
  with Database.SQLStatisticsMaker do
  begin
+  SetIntValue(stText,'LogFlag1',1);
   SetStringValue(stText,scLastQuery,CmpFullName(Self));
   FixStartTime(stText,scLastTimeExecute);
   IncCounter(stText,scExecuteCount);
@@ -3801,7 +3802,8 @@ begin
 end;
 
 procedure TFIBQuery.EndStatisticExec(const stText:string);
-var lt,s,j:integer;
+var j:integer;
+    lt,s:int64;
     ts:TStrings;
 begin
  if Assigned(Database.SQLStatisticsMaker) and  Database.SQLStatisticsMaker.ActiveStatistics then

--- a/pFIBInterfaces.pas
+++ b/pFIBInterfaces.pas
@@ -51,19 +51,22 @@ type
   ISQLStatMaker = interface
   ['{39477B70-12C9-4F70-993E-0E1067A8D649}']
 // For Statistics
-   function    FixStartTime(const ObjName,VarName:string):Integer;
-   function    FixEndTime(const ObjName,VarName:string):Integer;
-   function    GetVarInt(const ObjName,VarName:string):Integer;
-   function    GetVarStr(const ObjName,VarName:string):string;
+   function    FixStartTime(const ObjName,VarName:string):Int64;
+   function    FixEndTime(const ObjName,VarName:string):Int64;
+   function    GetVarInt(const ObjName,VarName:string):Int64; overload;
+   function    GetVarInt(const index: Integer; VarName:string):Int64; overload;
+   function    GetVarStr(const ObjName,VarName:string):string; overload;
+   function    GetVarStr(const index: Integer; VarName:string):string; overload;
    function    IncCounter(const ObjName,VarName:string):Integer;
    procedure   SetNull(const ObjName,VarName:string);
    procedure   SetStringValue(const ObjName,VarName,Value:string);
-   function    AddIntValue(const ObjName,VarName:string;Value:integer):integer;
-   procedure   SetIntValue(const ObjName,VarName:string;Value:integer);
+   function    AddIntValue(const ObjName,VarName:string;Value:Int64):Int64;
+   procedure   SetIntValue(const ObjName,VarName:string;Value:Int64);
 //
    procedure   AddToStrings(const ObjName,VarName,Value:string);
    procedure   ClearStrings(const ObjName,VarName:string);
-   function    GetVarStrings(const ObjName,VarName:string):TStrings;
+   function    GetVarStrings(const ObjName,VarName:string):TStrings; overload;
+   function    GetVarStrings(const index: Integer; VarName: string): TStrings; overload;
    procedure   Clear;
 
    procedure   SetActiveStatistics(const Value:boolean);


### PR DESCRIPTION
Better time "resolution" in statistics

Now using QueryPerformanceCounter and QueryryPerformanceFrequency to provide high resolution (<1us) execution durations (on Windows). Was GetTickCount (returns only milliseconds).